### PR TITLE
components MainScene: load DetailsView only for selected item

### DIFF
--- a/components/MainScene.brs
+++ b/components/MainScene.brs
@@ -50,8 +50,15 @@ end sub
 sub OnGridItemSelected(event as Object)
     grid = event.GetRoSGNode()
     selectedIndex = event.GetData()
-    rowContent = grid.content.GetChild(selectedIndex[0])
-    detailsView = ShowDetailsView(rowContent, selectedIndex[1])
+
+    ' selectedIndex[0] is row, selectedIndex[1] is column; using GetChild() sequentially gets the selected item
+    selectedContent = grid.content.GetChild(selectedIndex[0]).GetChild(selectedIndex[1])
+
+    ' populating a DetailsView with only the selected item, index 0, and "false" for "not a content list"
+    ' this prevents the app from treating the entire row as a playlist, so when the stream stops playing,
+    ' it doesn't autoplay the next one
+
+    detailsView = ShowDetailsView(selectedContent, 0, false)
     detailsView.ObserveField("wasClosed", "OnDetailsWasClosed")
 end sub
 


### PR DESCRIPTION
In the default app template, selecting an item from the MainScene loads its entire row into the DetailsView, which treats the entire row as a playlist.  This would mean when a stream went offline, it would auto- play the next stream in the row.

Rather than refactor out the entire "row as playlist" metaphor, this commit hacks a simple solution-- load only the selected item into the DetailsView and specify "not a content list", which locks down the UI to working with only the selected stream and not the entire row.

Resolves issue #9.