### PR TITLE
Add "favorites" feature and badging for live streams

### DIFF
--- a/components/DetailsViewLogic.brs
+++ b/components/DetailsViewLogic.brs
@@ -23,10 +23,11 @@ end function
 
 sub OnDetailsContentSet(event as Object)
     btnsContent = CreateObject("roSGNode", "ContentNode")
-    if event.GetData().TITLE = "series"
-        btnsContent.Update({ children: [{ title: "Episodes", id: "episodes" }] })
+    content = event.getData()
+    if content.favorite
+        btnsContent.Update({ children: [{ title: "Play", id: "play" }, { title: "Remove Favorite", id: "remove-favorite"}] })
     else
-        btnsContent.Update({ children: [{ title: "Play", id: "play" }] })
+        btnsContent.Update({ children: [{ title: "Play", id: "play" }, { title: "Add Favorite", id: "add-favorite"}] })
     end if
 
     details = event.GetRoSGNode()
@@ -40,8 +41,18 @@ sub OnButtonSelected(event as Object)
     if selectedButton.id = "play"
         videoView = OpenVideoPlayer(details.content, details.itemFocused, details.isContentList)
         videoView.ObserveField("wasClosed", "OnVideoWasClosed")
-    else if selectedButton.id = "episodes"
-        ShowEpisodePickerView(details.currentItem.seasons)
+    else if selectedButton.id = "add-favorite"
+        favorites = Utils_GetFavorites()
+        favorites.AddReplace(details.content.id, true)
+        Utils_SaveFavorites(favorites)
+        details.content.favorite = true
+        details.content.favoriteUpdated = true
+    else if selectedButton.id = "remove-favorite"
+        favorites = Utils_GetFavorites()
+        favorites.Delete(details.content.id)
+        Utils_SaveFavorites(favorites)
+        details.content.favorite = false
+        details.content.favoriteUpdated = true
     end if
 end sub
 

--- a/components/MainScene.brs
+++ b/components/MainScene.brs
@@ -26,6 +26,9 @@ sub Show(args as Object)
     m.grid.SetFields({
         style: "standard"
         posterShape: "16x9"
+        theme: {
+            itemTextBackgroundColor: "0x00000080"
+        }
     })
     content = CreateObject("roSGNode", "ContentNode")
     content.AddFields({
@@ -64,7 +67,17 @@ end sub
 
 sub OnDetailsWasClosed(event as Object)
     details = event.GetRoSGNode()
-    m.grid.jumpToRowItem = [m.grid.rowItemFocused[0], details.itemFocused]
+    if details.content.favoriteUpdated = true
+        content = CreateObject("roSGNode", "ContentNode")
+        content.AddFields({
+            HandlerConfigGrid: {
+                name: "RootHandler"
+            }
+        })
+        m.grid.content = content
+    else
+        m.grid.jumpToRowItem = [m.grid.rowItemFocused[0], details.itemFocused]
+    end if
 end sub
 
 sub Input(args as object)

--- a/source/rsg_utils.brs
+++ b/source/rsg_utils.brs
@@ -58,3 +58,16 @@ Function Utils_ContentList2Node(contentList as Object) as Object
 
     return result
 End Function
+
+function Utils_GetFavorites() as dynamic
+    sec = CreateObject("roRegistrySection", "Favorites")
+    if sec.Exists("Favorites")
+        return ParseJson(sec.Read("Favorites"))
+    end if
+    return {}
+end function
+
+function Utils_SaveFavorites(favorites) as boolean
+    sec = CreateObject("roRegistrySection", "Favorites")
+    return sec.Write("Favorites", FormatJson(favorites))
+end function


### PR DESCRIPTION
This commit introduces two features: favorites and badging for live feeds.  These are being added together in one commit because the former really strongly depends on the latter.  That is, once a user has favorites, wanting to know if a favorite is live is essential.

The UI flow is very simple and works with what's already present in the app.  When selecting a feed and going to its details page, there is the option to add it as a favorite or remove it from favorites if it was previously added.  Additionaly, the "Favorites" row appears only if the user has selected some favorites.

This is a feature that's going to have some jank to it.  It only stores the ID from the directory for a feed and relies on its directory entry to gather details.  If a stream disappears from the directory, it'll disappear from the user's favorites, too.  This could mean a slight leakage of storage space and a little UI jank if someone favorites a feed that disappears for months.  But, this can be cleaned up with future work.

Additionally, because the "Favorites" row will contain a mix of live and not-live streams, this commit adds a "LIVE" badge to any stream that has the "now-live" tag, making it easier to browse favorites and topical rows for the currently live streams.  Probably, in the future, we should move all the live feeds to the front of their respective rows.