### PR TITLE
Display thumbnail if stream is live, fallback to logo

### DIFF
--- a/components/contentData/ChannelData.xml
+++ b/components/contentData/ChannelData.xml
@@ -3,6 +3,8 @@
 <component name="ChannelData" extends="ContentNode">
     <interface>
         <field id="focus" type="boolean" />
+        <field id="logoImageURI" type="string" />
+        <field id="thumbnailImageURI" type="string" />
         <field id="isFavorite" type="boolean" />
         <field id="tags" type="array" />
     </interface>

--- a/components/items/ChannelItem.bs
+++ b/components/items/ChannelItem.bs
@@ -1,5 +1,9 @@
+import "pkg:/source/Misc.bs"
+import "pkg:/source/enums/PosterLoadStatus.bs"
+
 sub init()
     m.itemImage = m.top.findNode("itemImage")
+    m.itemImage.observeFieldScoped("loadStatus", "onLoadStatusChange")
 
     m.liveLabel = m.top.findNode("liveLabel")
     m.liveText = m.top.findNode("liveText")
@@ -12,13 +16,29 @@ sub init()
     m.itemSubText.font.size = 15
 end sub
 
+sub onLoadStatusChange()
+    if isStringEqual(m.itemImage.loadStatus, PosterLoadStatus.LOADING) then return
+
+    if isStringEqual(m.itemImage.loadStatus, PosterLoadStatus.READY) then m.itemImage.unobserveFieldScoped("loadStatus")
+
+    if isStringEqual(m.itemImage.loadStatus, PosterLoadStatus.FAILED)
+        if isStringEqual(m.itemImage.uri, m.top.itemContent.thumbnailImageURI)
+            m.itemImage.uri = m.top.itemContent.logoImageURI
+            return
+        end if
+    end if
+
+    m.itemImage.unobserveFieldScoped("loadStatus")
+end sub
+
 sub itemContentChanged()
     itemData = m.top.itemContent
-    m.itemImage.uri = itemData.HDPosterUrl
+
     m.itemText.text = itemData.title
     m.itemSubText.text = itemData.SecondaryTitle
-
     m.itemSubText.repeatCount = itemData.focus ? - 1 : 0
     m.liveLabel.visible = itemData.live
+
+    m.itemImage.uri = itemData.live ? itemData.thumbnailImageURI : itemData.logoImageURI
 end sub
 

--- a/components/scenes/MainScene.bs
+++ b/components/scenes/MainScene.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/Misc.bs"
+import "pkg:/source/api/OwncastSDK.bs"
 import "pkg:/source/enums/Constant.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/TaskControl.bs"
@@ -60,8 +61,9 @@ sub sortData()
             itemID = feed.LookupCI("id").toStr()
             isFavorite = userFavorites.LookupCI(itemID) ?? false
             itemSecondaryTitle = getStreamTitle(feed)
-            itemHDPosterUrl = `${feed.LookupCI("url")}${feed.LookupCI("logo")}`
             isLive = streamSection.LookupCI("online") ?? false
+            logoImageURI = `${feed.LookupCI("url")}${feed.LookupCI("logo")}`
+            thumbnailImageURI = api.image.getThumbnailURL(itemID)
 
             thisItemTags.push({
                 slug: isLive ? "now-live" : "now-offline"
@@ -81,7 +83,8 @@ sub sortData()
                     thisItem.tags = thisItemTags
                     thisItem.title = itemTitle
                     thisItem.SecondaryTitle = itemSecondaryTitle
-                    thisItem.HDPosterUrl = itemHDPosterUrl
+                    thisItem.thumbnailImageURI = thumbnailImageURI
+                    thisItem.logoImageURI = logoImageURI
                     thisItem.length = 0
                     thisItem.isFavorite = isFavorite
                     thisItem.url = `${feed.LookupCI("url")}/hls/stream.m3u8`

--- a/components/scenes/StreamDetails.bs
+++ b/components/scenes/StreamDetails.bs
@@ -1,10 +1,13 @@
 import "pkg:/source/Misc.bs"
 import "pkg:/source/enums/KeyCode.bs"
+import "pkg:/source/enums/PosterLoadStatus.bs"
 
 sub init()
     m.title = m.top.findNode("title")
     m.subtitle = m.top.findNode("subtitle")
     m.posterImage = m.top.findNode("posterImage")
+    m.posterImage.observeFieldScoped("loadStatus", "onLoadStatusChange")
+
     m.tags = m.top.findNode("tags")
     m.tags.font.size = 20
 
@@ -33,8 +36,12 @@ sub onChannelDataChanged()
     end if
 
     if isValid(m.posterImage)
-        if isChainValid(m.top.channelData, "hdposterurl")
-            m.posterImage.uri = m.top.channelData.hdposterurl
+        if not isChainValid(m.top.channelData, "live")
+            m.posterImage.uri = m.top.channelData.logoImageURI
+        else
+            if isChainValid(m.top.channelData, "thumbnailImageURI") and isChainValid(m.top.channelData, "logoImageURI")
+                m.posterImage.uri = m.top.channelData.live ? m.top.channelData.thumbnailImageURI : m.top.channelData.logoImageURI
+            end if
         end if
     end if
 
@@ -75,6 +82,21 @@ sub onChannelDataChanged()
             processFavoriteButton()
         end if
     end if
+end sub
+
+sub onLoadStatusChange()
+    if isStringEqual(m.posterImage.loadStatus, PosterLoadStatus.LOADING) then return
+
+    if isStringEqual(m.posterImage.loadStatus, PosterLoadStatus.READY) then m.posterImage.unobserveFieldScoped("loadStatus")
+
+    if isStringEqual(m.posterImage.loadStatus, PosterLoadStatus.FAILED)
+        if isStringEqual(m.posterImage.uri, m.top.channelData.thumbnailImageURI)
+            m.posterImage.uri = m.top.channelData.logoImageURI
+            return
+        end if
+    end if
+
+    m.posterImage.unobserveFieldScoped("loadStatus")
 end sub
 
 sub toggleFavorite()

--- a/source/api/OwncastSDK.bs
+++ b/source/api/OwncastSDK.bs
@@ -6,4 +6,10 @@ namespace api
             return getJson(`https://directory.owncast.online/api/home`)
         end function
     end namespace
+
+    namespace image
+        function getThumbnailURL(streamID as string) as dynamic
+            return `https://directory.owncast.online/api/image/thumb/${streamID}?cachebuster=${Rnd(100000)}`
+        end function
+    end namespace
 end namespace


### PR DESCRIPTION
On home and stream detail screens, if stream is live then show thumbnail image, otherwise display logo image.

If thumbnail image loading fails, fallback to logo image.

Fixes #5